### PR TITLE
Feature/flickr image queue

### DIFF
--- a/FlickrSlideShow.xcodeproj/project.pbxproj
+++ b/FlickrSlideShow.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		6C65ED4C209408A20029FBD5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6C65ED4A209408A20029FBD5 /* LaunchScreen.storyboard */; };
 		6C65ED57209408A20029FBD5 /* FlickrSlideShowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C65ED56209408A20029FBD5 /* FlickrSlideShowTests.swift */; };
 		6C833560209488B300662188 /* StartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C65ED43209408A10029FBD5 /* StartViewController.swift */; };
+		6C8335622094BCF100662188 /* FlickrImageQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C8335612094BCF100662188 /* FlickrImageQueue.swift */; };
 		6CF62F5220945F610043B409 /* FlickrImageAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF62F5120945F610043B409 /* FlickrImageAPI.swift */; };
 		6CF62F54209460080043B409 /* FlickrURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF62F53209460080043B409 /* FlickrURL.swift */; };
 		6CF62F572094626F0043B409 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CF62F562094626F0043B409 /* String.swift */; };
@@ -45,6 +46,7 @@
 		6C65ED52209408A20029FBD5 /* FlickrSlideShowTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = FlickrSlideShowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C65ED56209408A20029FBD5 /* FlickrSlideShowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlickrSlideShowTests.swift; sourceTree = "<group>"; };
 		6C65ED58209408A20029FBD5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		6C8335612094BCF100662188 /* FlickrImageQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlickrImageQueue.swift; sourceTree = "<group>"; };
 		6CF62F5120945F610043B409 /* FlickrImageAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlickrImageAPI.swift; sourceTree = "<group>"; };
 		6CF62F53209460080043B409 /* FlickrURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlickrURL.swift; sourceTree = "<group>"; };
 		6CF62F562094626F0043B409 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
@@ -136,6 +138,7 @@
 				6CF62F53209460080043B409 /* FlickrURL.swift */,
 				6C52577F20946F9E00097E91 /* FlickrPublicFeedResponse.swift */,
 				6C52578120946FBB00097E91 /* FlickrImageMetaData.swift */,
+				6C8335612094BCF100662188 /* FlickrImageQueue.swift */,
 			);
 			path = FlickrAPI;
 			sourceTree = "<group>";
@@ -254,6 +257,7 @@
 				6CF62F572094626F0043B409 /* String.swift in Sources */,
 				6C65ED42209408A10029FBD5 /* AppDelegate.swift in Sources */,
 				6CF62F5220945F610043B409 /* FlickrImageAPI.swift in Sources */,
+				6C8335622094BCF100662188 /* FlickrImageQueue.swift in Sources */,
 				6C52578020946F9E00097E91 /* FlickrPublicFeedResponse.swift in Sources */,
 				6C52578220946FBB00097E91 /* FlickrImageMetaData.swift in Sources */,
 				6C46DE77209424EB00EE7F54 /* SlideViewController.swift in Sources */,

--- a/FlickrSlideShow/Extension/String.swift
+++ b/FlickrSlideShow/Extension/String.swift
@@ -11,6 +11,11 @@ import Foundation
 //TODO: Should I bound check? It'd be safe if bound check can stop termination by exception
 
 extension String {
+  
+  var nsString: NSString {
+    return NSString(string: self)
+  }
+  
   private func cut(start: Int, end: Int) -> String.SubSequence {
     let startIndex = self.index(self.startIndex, offsetBy: start)
     let endIndex = self.index(self.startIndex, offsetBy: end)
@@ -37,5 +42,4 @@ extension String {
   subscript(_ sequence: PartialRangeThrough<Int>) -> String {
     return String(self.cut(start: 0, end: sequence.upperBound))
   }
-  
 }

--- a/FlickrSlideShow/FlickrAPI/FlickrImageAPI.swift
+++ b/FlickrSlideShow/FlickrAPI/FlickrImageAPI.swift
@@ -55,6 +55,7 @@ final class FlickrImageAPI {
     task.resume()
   }
   
+  ///Get image from url
   func image(from metaData: FlickrImageMetaData, completion: @escaping (UIImage?, Error?) -> Void) {
     guard let requestURL = URL(string: metaData.mediaLink)
     else { return completion(nil, ResponseError.urlInvalid) }

--- a/FlickrSlideShow/FlickrAPI/FlickrImageQueue.swift
+++ b/FlickrSlideShow/FlickrAPI/FlickrImageQueue.swift
@@ -1,0 +1,98 @@
+//
+//  FlickrImageQueue.swift
+//  FlickrSlideShow
+//
+//  Created by 김범수 on 2018. 4. 28..
+//  Copyright © 2018년 bs. All rights reserved.
+//
+
+import UIKit
+
+//I want it to be fresh all the time
+//HOw?
+
+//filter Bool and if empty go old ones
+//and at the same time request must be explicitly made once
+//Also! It should maintain it's size atmost 40ish?
+
+//Objective when pouring Rx.
+//1. If all image request ends, then be ready to make new request
+//2. make two consecutive requests as single observable
+
+final class FlickrImageQueue {
+  private var metaDataQueue: [(hasExposed: Bool, metaData: FlickrImageMetaData)] = []
+  private var imageCache = NSCache<NSString, UIImage>()
+  let maxQueueLength = 40
+  var currentIndex = 0
+  
+  init() {
+    imageCache.countLimit = 100
+  }
+  
+  //
+  private func requestNewImages() {
+    DispatchQueue.global(qos: .background).async {
+      
+      FlickrImageAPI.shared.listFromPublicFeed { [weak self] response, error in
+        guard error == nil,
+          let response = response
+        else {
+          DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 0.5, execute: {
+            self?.requestNewImages()
+          })
+          return
+        }
+        
+        response.items.forEach { metaData in
+          FlickrImageAPI.shared.image(from: metaData) { image, error in
+            guard let image = image
+              else { return }
+            
+            self?.imageCache.setObject(image, forKey: metaData.mediaLink.nsString)
+            self?.metaDataQueue.append((false, metaData))
+          }
+        }
+        
+      }
+      
+    }
+  }
+  
+  /**
+   - important: I think code quality here is not very unsatifying.
+   
+   Since metaDataQueue gets appended asynchronously, I had to add bound check logic in this function which led to bad readability.
+   
+   Code cleaning needed
+   - returns: New Image and metadata from feed
+   */
+  func imageWithMetaData() -> (FlickrImageMetaData, UIImage)? {
+    let exposedList = metaDataQueue.filter { $0.hasExposed }
+    let freshList = metaDataQueue.filter { !$0.hasExposed }
+    
+    if freshList.isEmpty {
+      requestNewImages()
+      
+      guard let metaData = exposedList.count > currentIndex ? exposedList[currentIndex].metaData : nil,
+        let image = imageCache.object(forKey: metaData.mediaLink.nsString)
+      else {
+        return nil
+      }
+      currentIndex += 1
+      return (metaData,image)
+    }
+    
+    guard let metaData = freshList.first?.metaData,
+      let image = imageCache.object(forKey: metaData.mediaLink.nsString)
+    else { return nil }
+    
+    metaDataQueue[exposedList.count].hasExposed = true
+    
+    if metaDataQueue.count > maxQueueLength {
+      metaDataQueue.removeFirst()
+      currentIndex -= 1
+    }
+    
+    return (metaData, image)
+  }
+}


### PR DESCRIPTION
Desciption

- FlickrImageQueue: FlickrImageQueue is class that emits fresh images from [Flickr Public Feed](https://www.flickr.com/services/feeds/docs/photos_public/). 
It returns nil when queue is empty(the very first state), otherwise returns image with metadata.
Since queue will only dispose old image when there is sufficient fresh images, it will never return nil since queue has filled.
bfd5a7a